### PR TITLE
Update image links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,37 +3,37 @@
 A collection of low profile split ergonomic mechanical keyboards I have created using [Ergogen](https://github.com/mrzealot/ergogen).
 
 ## Sepia officinalis
-![Sepia officinalis](images/sepia_officinalis.png)
+![Sepia officinalis](Images/sepia_officinalis.png)
 AKA S. officinalis, S.O., "Cuttlefish"
 
 34 keys, aggresive pinky stagger with top row omitted.
 
 ## Metasepia pfefferi
-![Metasepia pfefferi](images/metasepia_pfefferi.png)
+![Metasepia pfefferi](Images/metasepia_pfefferi.png)
 AKA M. pfefferi, M.P., "Flamboyant cuttlefish"
 
 26 keys, similar to the S. officinalis, but with top/bottom keys of pinky and inner columns omitted. 2 thumb keys.
 
 ## Dosidicus gigas
-![Dosidicus gigas](images/dosidicus_gigas.png)
+![Dosidicus gigas](Images/dosidicus_gigas.png)
 AKA D. gigas, D.G., "Jumbo squid"
 
 32 keys, same pinky stagger as S. officinalis and M. pfefferi, but with all "alpha" keys included. Pinky, ring, index, and inner columns splayed at 15, 5, -5, -5 degrees from middle column.
 
 ## Todarodes pacificus
-![Todarodes pacificus](images/todarodes_pacificus.png)
+![Todarodes pacificus](Images/todarodes_pacificus.png)
 AKA T. pacificus, T.P., "Japanese flying squid"
 
 30 keys, 15, 5, 0, -5, -5 degree splay. My take on the Hummingbird layout.
 
 ## Todarodes sagittatus
-![Todarodes sagittatus](images/todarodes_sagittatus.png)
+![Todarodes sagittatus](Images/todarodes_sagittatus.png)
 AKA T. sagittatus, T.S., "European flying squid"
 
 Same stagger as the T. pacificus, but no splay.
 
 ## Idiosepius thailandicus
-![Idiosepius thailandicus](images/idiosepius_thailandicus.png)
+![Idiosepius thailandicus](Images/idiosepius_thailandicus.png)
 AKA I. thailandicus, I.T., "Pygmy bobtail squid"
 
 Designed with the ARTSEY layout in mind, but could also be used with ASTENIOP.


### PR DESCRIPTION
Alternatively, you can `git mv Images images` and push that up. Wasn't sure how to do it in the github ui.

Good luck with the 28 journey.
My current main is a MX qwerty reviung34 (not the split but the one that looks like a reviung39 in 10u). Am working to reduce mod-tap and possibly transitioning to colemak-dh. the vi like modes is interesting and we'll see how that goes.

Thanks for the very informative videos. Your keymaps are filled with some great ideas.